### PR TITLE
feat: add maven-non-root-jdk-17 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This repository stores Dockerfiles and corresponding configurations for docker i
 
 An image using JDK-11 and maven while running under a non-root user. This for example is required when running embedded databases (PostgresSQL) in docker containers.
 
+### maven-non-root-jdk-17
+
+An image using JDK-17 and maven 3.8.4 while running under a non-root user. This for example is required when running embedded databases (PostgresSQL) in docker containers.
+
 ### maven-go-docker
 
 Specialized docker image for use with our internal CI system. Supplies maven, JDK-11, go and docker.

--- a/maven-non-root-jdk-17/Dockerfile
+++ b/maven-non-root-jdk-17/Dockerfile
@@ -1,0 +1,27 @@
+FROM openjdk:17-jdk-alpine
+
+RUN adduser maven --disabled-password
+
+RUN apk --no-cache add curl
+
+ARG MAVEN_VERSION=3.8.4
+ARG USER_HOME_DIR="/home/maven"
+ARG SHA=a9b2d825eacf2e771ed5d6b0e01398589ac1bfa4171f36154d1b5787879605507802f699da6f7cfc80732a5282fd31b28e4cd6052338cbef0fa1358b48a5e3c8
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+COPY settings.xml $MAVEN_CONFIG/settings.xml
+RUN mkdir $MAVEN_CONFIG/repository
+RUN chown maven:maven $USER_HOME_DIR -R
+
+USER maven
+CMD ["mvn"]

--- a/maven-non-root-jdk-17/settings.xml
+++ b/maven-non-root-jdk-17/settings.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <localRepository>/home/maven/.m2/repository</localRepository>
+</settings>


### PR DESCRIPTION
Adds an image similar to `maven-non-root` but with JDK-17 and maven 3.8.4