### PR TITLE
workflow to push maven-non-root-jdk-17 image to docker hub

### DIFF
--- a/.github/workflows/maven-non-root-jdk-17-push.yml
+++ b/.github/workflows/maven-non-root-jdk-17-push.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+    tags:
+      - 'maven-non-root-jdk-17-v*'
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: inheadendev/maven-non-root-jdk-17
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: maven-non-root-jdk-17
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Pushes the maven-non-root-jdk-17 image to docker hub on maven-non-root-jdk-17-v* tags